### PR TITLE
Only printf when _DEBUG

### DIFF
--- a/nbqmemory/nbqmemory.cpp
+++ b/nbqmemory/nbqmemory.cpp
@@ -33,8 +33,9 @@ bool nbqmemory::attach(const char* process_name, DWORD access_rights)
 		}
 		CloseHandle(ss);
 	}
+#ifdef _DEBUG
 	printf("process_handle(%s): 0x%x\n", process_name, (DWORD)this->process_handle);
-	if (this->process_handle) { return true; } else { return false; }	
+#endif	if (this->process_handle) { return true; } else { return false; }	
 }
 
 bool nbqmemory::detach()


### PR DESCRIPTION
To avoid clutter, only print the debug information when the user is in debug mode (_DEBUG flag is set).